### PR TITLE
Disable DLOG(x) for release build without GLog; Add GLog support for Win32; ...

### DIFF
--- a/CMakeLists4Windows.txt
+++ b/CMakeLists4Windows.txt
@@ -78,7 +78,7 @@ if(POOLAGENT__USE_GLOG)
   set(CompilerFlags CMAKE_CXX_FLAGS_DEBUG CMAKE_C_FLAGS_DEBUG
                     CMAKE_CXX_FLAGS_RELEASE CMAKE_C_FLAGS_RELEASE)
   foreach(CompilerFlag ${CompilerFlags})
-    set(${CompilerFlag} "${${CompilerFlag}} /DSUPPORT_GLOG")
+    set(${CompilerFlag} "${${CompilerFlag}} /DGOOGLE_GLOG_DLL_DECL= /DSUPPORT_GLOG")
     message("${CompilerFlag}=${${CompilerFlag}}")
   endforeach()
 else()

--- a/CMakeLists4Windows.txt
+++ b/CMakeLists4Windows.txt
@@ -22,14 +22,15 @@ option(POOLAGENT__USE_IOCP
   "Use IOCP (I/O Completion Port) replace select() for libevent" OFF)
 
 if(POOLAGENT__USE_IOCP)
-  message("Use IOCP (I/O Completion Port) for libevent")
-  set(CompilerFlags CMAKE_CXX_FLAGS_DEBUG CMAKE_C_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE CMAKE_C_FLAGS_RELEASE)
+  message("-- Use IOCP (I/O Completion Port) for libevent")
+  set(CompilerFlags CMAKE_CXX_FLAGS_DEBUG CMAKE_C_FLAGS_DEBUG
+                    CMAKE_CXX_FLAGS_RELEASE CMAKE_C_FLAGS_RELEASE)
   foreach(CompilerFlag ${CompilerFlags})
     set(${CompilerFlag} "${${CompilerFlag}} /DUSE_IOCP")
     message("${CompilerFlag}=${${CompilerFlag}}")
   endforeach()
 else()
-  message("Use select() for libevent")
+  message("-- Use select() for libevent")
   message("(-DPOOLAGENT__USE_IOCP=ON switching to IOCP)")
 endif()
 
@@ -41,7 +42,7 @@ option(POOLAGENT__STATIC_LINKING_VC_LIB
   "Static linking VC++ runtime library (/MT)" OFF)
 
 if(POOLAGENT__STATIC_LINKING_VC_LIB)
-  message("Static linking VC++ runtime library (/MT).")
+  message("-- Static linking VC++ runtime library (/MT).")
   
   # debug mode
   set(CompilerFlags CMAKE_CXX_FLAGS_DEBUG CMAKE_C_FLAGS_DEBUG)
@@ -61,21 +62,48 @@ if(POOLAGENT__STATIC_LINKING_VC_LIB)
     message("${CompilerFlag}=${${CompilerFlag}}")
   endforeach()
 else()
-  message("Dynamic linking VC++ runtime library (/MD).")
+  message("-- Dynamic linking VC++ runtime library (/MD).")
   message("(-DPOOLAGENT__STATIC_LINKING_VC_LIB=ON switching to static linking.)")
+endif()
+
+
+###
+# Use GLog for logging replace stdout
+###
+option(POOLAGENT__USE_GLOG
+  "Use GLog for logging replace stdout" OFF)
+
+if(POOLAGENT__USE_GLOG)
+  message("-- Use GLog for logging")
+  set(CompilerFlags CMAKE_CXX_FLAGS_DEBUG CMAKE_C_FLAGS_DEBUG
+                    CMAKE_CXX_FLAGS_RELEASE CMAKE_C_FLAGS_RELEASE)
+  foreach(CompilerFlag ${CompilerFlags})
+    set(${CompilerFlag} "${${CompilerFlag}} /DSUPPORT_GLOG")
+    message("${CompilerFlag}=${${CompilerFlag}}")
+  endforeach()
+else()
+  message("-- Use stdout for logging")
+  message("(-DPOOLAGENT__USE_GLOG=ON switching to GLog)")
 endif()
 
 
 SET(CMAKE_CXX_COMPILER_ARG1 "-std=c++98")
 SET(CMAKE_C_COMPILER_ARG1 "-std=c99")
 
+if(POOLAGENT__USE_GLOG)
+  find_package(Glog)
+  if(NOT GLOG_FOUND)
+    message(FATAL_ERROR "Glog not found!")
+  endif(NOT GLOG_FOUND)
+endif()
+
 find_package(LibEvent)
 if(NOT LibEvent_FOUND)
   message(FATAL_ERROR "libevent2 not found!")
 endif(NOT LibEvent_FOUND)
 
-include_directories(src test ${LIBEVENT_INCLUDE_DIR})
-set(THRID_LIBRARIES ${LIBEVENT_LIB})
+include_directories(src test ${GLOG_INCLUDE_DIRS} ${LIBEVENT_INCLUDE_DIR})
+set(THRID_LIBRARIES ${GLOG_LIBRARIES} ${LIBEVENT_LIB})
 
 file(GLOB LIB_SOURCES src/*.cc src/*.c)
 add_library(btccomagent STATIC ${LIB_SOURCES})

--- a/CMakeLists4Windows.txt
+++ b/CMakeLists4Windows.txt
@@ -14,9 +14,32 @@ ELSE()
   message("Release build.")
 ENDIF()
 
+
+###
+# Use IOCP (I/O Completion Port) replace select() for libevent
+###
+option(POOLAGENT__USE_IOCP
+  "Use IOCP (I/O Completion Port) replace select() for libevent" OFF)
+
+if(POOLAGENT__USE_IOCP)
+  message("Use IOCP (I/O Completion Port) for libevent")
+  set(CompilerFlags CMAKE_CXX_FLAGS_DEBUG CMAKE_C_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE CMAKE_C_FLAGS_RELEASE)
+  foreach(CompilerFlag ${CompilerFlags})
+    set(${CompilerFlag} "${${CompilerFlag}} /DUSE_IOCP")
+    message("${CompilerFlag}=${${CompilerFlag}}")
+  endforeach()
+else()
+  message("Use select() for libevent")
+  message("(-DPOOLAGENT__USE_IOCP=ON switching to IOCP)")
+endif()
+
+
 ###
 # static linking VC++ runtime library
 ###
+option(POOLAGENT__STATIC_LINKING_VC_LIB
+  "Static linking VC++ runtime library (/MT)" OFF)
+
 if(POOLAGENT__STATIC_LINKING_VC_LIB)
   message("Static linking VC++ runtime library (/MT).")
   
@@ -39,8 +62,9 @@ if(POOLAGENT__STATIC_LINKING_VC_LIB)
   endforeach()
 else()
   message("Dynamic linking VC++ runtime library (/MD).")
-  message("Use -DPOOLAGENT__STATIC_LINKING_VC_LIB=ON for static linking.")
+  message("(-DPOOLAGENT__STATIC_LINKING_VC_LIB=ON switching to static linking.)")
 endif()
+
 
 SET(CMAKE_CXX_COMPILER_ARG1 "-std=c++98")
 SET(CMAKE_C_COMPILER_ARG1 "-std=c99")

--- a/README-Windows.md
+++ b/README-Windows.md
@@ -48,6 +48,15 @@ start PoolAgent.sln
 
 Then build ```ALL_BUILD``` project in Visual Studio. ```build\Debug\agent.exe``` is the final product, it static linked with libevent. But by default, it dynamic linked with VC++ runtime library. You must install ```Visual C++ Redistributable for Visual Studio 20xx``` at another computers.
 
+There are ```btcagent``` specific Cmake variables (the values being the default):
+
+```
+# Static linking VC++ runtime library (/MT)
+POOLAGENT__STATIC_LINKING_VC_LIB:BOOL=OFF
+
+# Use IOCP (I/O Completion Port) replace select() for libevent
+POOLAGENT__USE_IOCP:BOOL=OFF
+```
 
 ## Static linking with VC++ runtime library
 

--- a/README-Windows.md
+++ b/README-Windows.md
@@ -32,7 +32,11 @@ The ```INSTALL``` project will install libevent to ```C:\Program Files (x86)\lib
 
 ### Glog
 
-Glog is disabled in Windows version. May it be available in future.
+GLog support is optional and testing for Win32 version. It cannot work with ```-DPOOLAGENT__STATIC_LINKING_VC_LIB=ON``` for my test.
+
+You can download & build it with ```google-glog.sln``` within the source code directory. And rename ```libglog.lib``` as ```glog.lib``` so CMake will find it. copy ```glob.lib``` to ```VS_install_dir\lib```, ```src/windows/glob``` to ```VS_install_dir\include```. At last, use ```cmake -DPOOLAGENT__USE_GLOG=ON ..``` for ```btcagent```. You cannot use ```-DPOOLAGENT__STATIC_LINKING_VC_LIB=ON``` at the same time, even if you build glog with ```/MT```. Or some symbols like ```std::ios_base``` will missing...
+
+If you have some advise for static linking VC++ runtime library with GLog, create an issue.
 
 
 ### btcagent
@@ -56,6 +60,9 @@ POOLAGENT__STATIC_LINKING_VC_LIB:BOOL=OFF
 
 # Use IOCP (I/O Completion Port) replace select() for libevent
 POOLAGENT__USE_IOCP:BOOL=OFF
+
+# Use GLog for logging replace stdout
+POOLAGENT__USE_GLOG:BOOL=OFF
 ```
 
 ## Static linking with VC++ runtime library
@@ -91,6 +98,13 @@ foreach(CompilerFlag ${CompilerFlags})
   message("${CompilerFlag}=${${CompilerFlag}}")
 endforeach()
 ```
+
+
+### GLog
+
+Build ```btcagent``` with GLog and static linking VC++ runtime library caused linking error. I don't know how to fix.
+
+If you have some advise for this, create an issue.
 
 
 ### btcagent

--- a/README-Windows.md
+++ b/README-Windows.md
@@ -34,7 +34,7 @@ The ```INSTALL``` project will install libevent to ```C:\Program Files (x86)\lib
 
 GLog support is optional and testing for Win32 version. It cannot work with ```-DPOOLAGENT__STATIC_LINKING_VC_LIB=ON``` for my test.
 
-You can download & build it with ```google-glog.sln``` within the source code directory. And rename ```libglog.lib``` as ```glog.lib``` so CMake will find it. copy ```glob.lib``` to ```VS_install_dir\lib```, ```src/windows/glob``` to ```VS_install_dir\include```. At last, use ```cmake -DPOOLAGENT__USE_GLOG=ON ..``` for ```btcagent```. You cannot use ```-DPOOLAGENT__STATIC_LINKING_VC_LIB=ON``` at the same time, even if you build glog with ```/MT```. Or some symbols like ```std::ios_base``` will missing...
+You can download & build it with ```google-glog.sln``` within the source code directory. And rename ```libglog.lib``` as ```glog.lib``` so CMake will find it. copy ```glob.lib``` to ```VS_install_dir\VC\lib```, ```src/windows/glob``` to ```VS_install_dir\VC\include```. At last, use ```cmake -DPOOLAGENT__USE_GLOG=ON ..``` for ```btcagent```. You cannot use ```-DPOOLAGENT__STATIC_LINKING_VC_LIB=ON``` at the same time, even if you build glog with ```/MT```. Or some symbols like ```std::ios_base``` will missing...
 
 If you have some advise for static linking VC++ runtime library with GLog, create an issue.
 

--- a/README-Windows.md
+++ b/README-Windows.md
@@ -13,7 +13,7 @@ Add ```CmakeInstallDirectory\bin``` to ```PATH``` environment variable.
 
 ### libevent
 
-There is no cmake support for ```libevent-2.0.x-stable```. You have to build it by yourself if you want to stable version. It has a ```makefile.nmake``` but unfinished and not recommended by developers.
+```libevent-2.0.x-stable``` is no cmake support. You have to build it by yourself if you want to stable version. It has a ```makefile.nmake``` but unfinished and not recommended by developers.
 
 And ```libevent-2.1.x-rc``` has good support for cmake. You can open a ```cmd``` and ```cd``` to the source code directory, then run these command:
 
@@ -32,11 +32,21 @@ The ```INSTALL``` project will install libevent to ```C:\Program Files (x86)\lib
 
 ### Glog
 
-GLog support is optional and testing for Win32 version. It cannot work with ```-DPOOLAGENT__STATIC_LINKING_VC_LIB=ON``` for my test.
+Last release ```glog: 0.3.4``` has an issue for VS2015 that duplicate definition ```snprintf``` at src/windows/port.cc, comment needed if using VS2015. Even that, the test case crashed with an exception.
 
-You can download & build it with ```google-glog.sln``` within the source code directory. And rename ```libglog.lib``` as ```glog.lib``` so CMake will find it. copy ```glob.lib``` to ```VS_install_dir\VC\lib```, ```src/windows/glob``` to ```VS_install_dir\VC\include```. At last, use ```cmake -DPOOLAGENT__USE_GLOG=ON ..``` for ```btcagent```. You cannot use ```-DPOOLAGENT__STATIC_LINKING_VC_LIB=ON``` at the same time, even if you build glog with ```/MT```. Or some symbols like ```std::ios_base``` will missing...
+Recommended version is the master branch from github, it fix the issue. The build command with cmake is:
 
-If you have some advise for static linking VC++ runtime library with GLog, create an issue.
+```cmd
+git clone https://github.com/google/glog.git
+mkdir glog/build
+cd glog/build
+cmake ..
+start -G "Visual Studio 14 2015" google-glog.sln
+```
+
+Then build ```ALL_BUILD``` & ```INSTALL``` project with VS2015, then copy ```C:\Program Files (x86)\google-glog\include``` & ```C:\Program Files (x86)\google-glog\lib``` to ```VS_install_dir\VC\```.
+
+If you build with ```google-glog.sln``` in the project root directory, you have to copy ```libglog_static.lib``` to ```VS_install_dir\VC\lib``` and rename it to ```glog.lib``` so cmake can find it when build ```btcagent```. (It isn't recommended because of ```snprintf``` issue.)
 
 
 ### btcagent
@@ -72,9 +82,9 @@ For static linking with VC++ runtime library, we use ```/MT``` in the project's 
 All librarys the project reliant must linked with ```/MT``` or ```/MTd```, else some symbols will lost at the final linking.
 
 
-### libevent
+### libevent & GLog
 
-You can add there codes to ```CMakeLists.txt``` of ```libevent``` that modify the default ```/MD``` & ```/MDd``` property to ```/MT``` & ```/MTd```:
+You can add there codes to the end of ```CMakeLists.txt``` that modify the default ```/MD``` & ```/MDd``` property to ```/MT``` & ```/MTd```:
 
 ```cmake
 ###
@@ -99,12 +109,7 @@ foreach(CompilerFlag ${CompilerFlags})
 endforeach()
 ```
 
-
-### GLog
-
-Build ```btcagent``` with GLog and static linking VC++ runtime library caused linking error. I don't know how to fix.
-
-If you have some advise for this, create an issue.
+Then build as normal.
 
 
 ### btcagent
@@ -141,3 +146,9 @@ agent.exe -c agent_conf.json
 run without stdout:
 ```cmd
 agent.exe -c agent_conf.json > nul
+```
+
+run with GLog enabled:
+```cmd
+agent.exe -c agent_conf.json -l log
+```

--- a/cmake/Modules/FindGlog.cmake
+++ b/cmake/Modules/FindGlog.cmake
@@ -13,29 +13,12 @@ include(FindPackageHandleStandardArgs)
 
 set(GLOG_ROOT_DIR "" CACHE PATH "Folder contains Google glog")
 
-if(WIN32)
-    find_path(GLOG_INCLUDE_DIR glog/logging.h
-        PATHS ${GLOG_ROOT_DIR}/src/windows)
-else()
-    find_path(GLOG_INCLUDE_DIR glog/logging.h
-        PATHS ${GLOG_ROOT_DIR})
-endif()
+find_path(GLOG_INCLUDE_DIR glog/logging.h
+    PATHS ${GLOG_ROOT_DIR})
 
-if(MSVC)
-    find_library(GLOG_LIBRARY_RELEASE libglog_static
-        PATHS ${GLOG_ROOT_DIR}
-        PATH_SUFFIXES Release)
-
-    find_library(GLOG_LIBRARY_DEBUG libglog_static
-        PATHS ${GLOG_ROOT_DIR}
-        PATH_SUFFIXES Debug)
-
-    set(GLOG_LIBRARY optimized ${GLOG_LIBRARY_RELEASE} debug ${GLOG_LIBRARY_DEBUG})
-else()
-    find_library(GLOG_LIBRARY glog
-        PATHS ${GLOG_ROOT_DIR}
-        PATH_SUFFIXES lib lib64)
-endif()
+find_library(GLOG_LIBRARY glog
+    PATHS ${GLOG_ROOT_DIR}
+    PATH_SUFFIXES lib lib64)
 
 find_package_handle_standard_args(Glog DEFAULT_MSG GLOG_INCLUDE_DIR GLOG_LIBRARY)
 

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -47,7 +47,7 @@
 #if defined(SUPPORT_GLOG)
   #include <glog/logging.h>
 #else
-  #define LOG(x) std::cout
+  #define LOG(x) std::cout << std::endl
 
   #ifdef NDEBUG
     // Disable debug output with Release build.
@@ -55,7 +55,7 @@
     // output streaming expression no matter a line break.
     #define DLOG(x) if(0)std::cout
   #else
-    #define DLOG(x) std::cout
+    #define DLOG(x) std::cout << std::endl
   #endif
 #endif
 

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -32,7 +32,7 @@
 
 
 #ifndef _WIN32
- #include <unistd.h>
+  #include <unistd.h>
 #endif
 
 #include <errno.h>
@@ -45,10 +45,18 @@
 #include "jsmn.h"
 
 #if defined(SUPPORT_GLOG)
- #include <glog/logging.h>
+  #include <glog/logging.h>
 #else
- #define LOG(x) std::cout
- #define DLOG(x) std::cout
+  #define LOG(x) std::cout
+
+  #ifdef NDEBUG
+    // Disable debug output with Release build.
+    // It's safe because compiler will ignore whole the
+    // output streaming expression no matter a line break.
+    #define DLOG(x) if(0)std::cout
+  #else
+    #define DLOG(x) std::cout
+  #endif
 #endif
 
 using  std::string;

--- a/test/TestMain.cc
+++ b/test/TestMain.cc
@@ -41,7 +41,7 @@ static void handler(int sig);
 
 // just for debug, should be removed when release
 void handler(int sig) {
-#if defined(SUPPORT_GLOG)
+#if defined(SUPPORT_GLOG) && ! defined(_WIN32)
   void *array[10];
   size_t size;
 
@@ -84,9 +84,7 @@ int main(int argc, char **argv) {
     newArgv[1] = (char*)testname.c_str();
   }
   
-#if defined(SUPPORT_GLOG)
   testing::InitGoogleTest(&argc, newArgv);
-#endif
 
   int ret = RUN_ALL_TESTS();
   delete [] newArgv;


### PR DESCRIPTION
Disable DLOG(x) for release build without GLog (some performance issue at Win32 & embedded system may solve);
Add GLog & IOCP support for Win32;
Fix: test case cannot run without GLog support;
Fix: line break missing when log to stdout.