### PR TITLE
修复与翼比特E12的兼容性

### DIFF
--- a/Config.go
+++ b/Config.go
@@ -88,6 +88,9 @@ type Config struct {
 			PoolSession        uint `json:"pool_session"`
 			MinerSession       uint `json:"miner_session"`
 		} `json:"message_queue_size"`
+
+		// 比特币的默认version mask（最开始发给矿机的version mask，连上矿池后值会被覆盖）
+		BitcoinDefaultVersionMask uint32 `json:"bitcoin_default_version_mask"`
 	} `json:"advanced"`
 
 	sessionFactory SessionFactory
@@ -113,6 +116,8 @@ func NewConfig() (config *Config) {
 	config.Advanced.MessageQueueSize.PoolSessionManager = UpSessionManagerChannelCache
 	config.Advanced.MessageQueueSize.PoolSession = UpSessionChannelCache
 	config.Advanced.MessageQueueSize.MinerSession = DownSessionChannelCache
+
+	config.Advanced.BitcoinDefaultVersionMask = BitcoinDefaultVersionMask
 
 	return
 }

--- a/Const.go
+++ b/Const.go
@@ -57,6 +57,9 @@ const (
 	CapSubmitResponse = "subres" // Send response of mining.submit
 )
 
+// BitcoinDefaultVersionMask 比特币的默认version mask
+const BitcoinDefaultVersionMask uint32 = 0x1fffe000
+
 const DownSessionDisconnectWhenLostAsicboost = true
 const UpSessionTLSInsecureSkipVerify = true
 

--- a/Event.go
+++ b/Event.go
@@ -120,3 +120,7 @@ type EventSetExtraNonce struct {
 type EventStratumJobETH struct {
 	Job *StratumJobETH
 }
+
+type EventSetVersionMask struct {
+	VersionMask uint32
+}

--- a/Utils.go
+++ b/Utils.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"encoding/hex"
+	"fmt"
 	"io"
 	"net"
 	"regexp"
@@ -233,4 +234,9 @@ func BinReverse(bin []byte) {
 		i++
 		j--
 	}
+}
+
+// VersionMaskStr 获取version mask的字符串表示
+func VersionMaskStr(mask uint32) string {
+	return fmt.Sprintf("%08x", mask)
 }

--- a/agent_conf.default.json
+++ b/agent_conf.default.json
@@ -34,6 +34,7 @@
             "pool_session_manager": 64,
             "pool_session": 512,
             "miner_session": 64
-        }
+        },
+        "bitcoin_default_version_mask": 536862720
     }
 }


### PR DESCRIPTION
之前的代码在mining.configure阶段，version_mask是ffffffff，随后发送mining.set_version_mask将其改为1fffe000，这似乎与翼比特E12不兼容，导致它不能正常挖矿。

所以添加了一个配置项BitcoinDefaultVersionMask，默认与服务器当前配置相同（0x1fffe000），如果服务器配置后续更改，还能在连上矿池后自动更新。因为目前的连接策略是矿池未就绪就把矿机踢下线，所以多用户模式最开始的连接获取不到正确的version mask也没关系，随后等连上矿池并更新version mask之后，矿机才能真正上线。

在进行这项改动后，请求我进行改动的矿工反馈称问题得到解决。备注：与此同时我还设置了`"always_keep_downconn": true`，也许是它解决了问题，我没有深入调查。

不过不管怎么说，这个修改的好处还是大于坏处的，因为它让智能代理更加符合 Version Rolling 的协议规范。

---

与矿工的聊天记录：

![与矿工的聊天记录](https://user-images.githubusercontent.com/4986069/172119569-3cf185e4-257f-4d93-8568-35885f3a2cd2.jpg)

