### PR TITLE
ETH：矿池已满后不再向其分配新矿机，防止始终出现“pool server is full”的问题

### DIFF
--- a/Event.go
+++ b/Event.go
@@ -58,6 +58,10 @@ type EventUpSessionBroken struct {
 	Slot int
 }
 
+type EventUpSessionFull struct {
+	Slot int
+}
+
 type EventSubmitShareBTC struct {
 	ID      interface{}
 	Message *ExMessageSubmitShareBTC

--- a/UpSessionBTC.go
+++ b/UpSessionBTC.go
@@ -307,7 +307,7 @@ func (up *UpSessionBTC) close() {
 		up.manager.SendEvent(EventUpSessionBroken{up.slot})
 	}
 
-	if up.config.AlwaysKeepDownconn {
+	if up.stat != StatExit && up.config.AlwaysKeepDownconn {
 		if up.lastJob != nil {
 			up.manager.SendEvent(EventUpdateFakeJobBTC{up.lastJob})
 		}

--- a/UpSessionETH.go
+++ b/UpSessionETH.go
@@ -295,7 +295,7 @@ func (up *UpSessionETH) close() {
 		up.manager.SendEvent(EventUpSessionBroken{up.slot})
 	}
 
-	if up.config.AlwaysKeepDownconn {
+	if up.stat != StatExit && up.config.AlwaysKeepDownconn {
 		if up.lastJob != nil {
 			up.manager.SendEvent(EventUpdateFakeJobETH{up.lastJob})
 		}
@@ -702,13 +702,13 @@ func (up *UpSessionETH) handleExMessageSetExtraNonce(ex *ExMessage) {
 		return
 	}
 
+	// 矿池服务器满了，无法连接新矿机
+	if msg.ExtraNonce == EthereumInvalidExtraNonce {
+		up.manager.SendEvent(EventUpSessionFull{up.slot})
+	}
+
 	down := up.downSessions[msg.SessionID]
 	if down != nil {
-		// 矿池服务器满了，无法连接新矿机
-		if msg.ExtraNonce == EthereumInvalidExtraNonce {
-			up.manager.SendEvent(EventUpSessionFull{up.slot})
-		}
-
 		down.SendEvent(EventSetExtraNonce{msg.ExtraNonce})
 		if up.lastJob != nil {
 			down.SendEvent(EventStratumJobETH{up.lastJob})

--- a/UpSessionETH.go
+++ b/UpSessionETH.go
@@ -704,6 +704,11 @@ func (up *UpSessionETH) handleExMessageSetExtraNonce(ex *ExMessage) {
 
 	down := up.downSessions[msg.SessionID]
 	if down != nil {
+		// 矿池服务器满了，无法连接新矿机
+		if msg.ExtraNonce == EthereumInvalidExtraNonce {
+			up.manager.SendEvent(EventUpSessionFull{up.slot})
+		}
+
 		down.SendEvent(EventSetExtraNonce{msg.ExtraNonce})
 		if up.lastJob != nil {
 			down.SendEvent(EventStratumJobETH{up.lastJob})


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4986069/173189749-8ae4857b-94d9-4d8e-bd59-7be841d8ef47.png)
