### PR TITLE
在矿池服务器已满时立即断开重连，防止一直出现“pool server is full”，新矿机连不上的问题

### DIFF
--- a/UpSessionBTC.go
+++ b/UpSessionBTC.go
@@ -307,7 +307,7 @@ func (up *UpSessionBTC) close() {
 		up.manager.SendEvent(EventUpSessionBroken{up.slot})
 	}
 
-	if up.config.AlwaysKeepDownconn {
+	if up.stat != StatExit && up.config.AlwaysKeepDownconn {
 		if up.lastJob != nil {
 			up.manager.SendEvent(EventUpdateFakeJobBTC{up.lastJob})
 		}


### PR DESCRIPTION
用户反馈称 https://github.com/btccom/btcagent/pull/46 效果不佳，有可能5个连接都已满，所以改成简单粗暴的一旦已满就重连。